### PR TITLE
Change to rtcm_msgs instead of mavros_msgs.

### DIFF
--- a/ublox_dgnss_node/CMakeLists.txt
+++ b/ublox_dgnss_node/CMakeLists.txt
@@ -27,7 +27,7 @@ find_package(rclcpp_components REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(ublox_ubx_msgs REQUIRED)
 find_package(ublox_ubx_interfaces REQUIRED)
-find_package(mavros_msgs REQUIRED)
+find_package(rtcm_msgs REQUIRED)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(libusb REQUIRED libusb-1.0)
@@ -49,7 +49,7 @@ ament_target_dependencies(ublox_dgnss_components
   std_msgs
   ublox_ubx_msgs
   ublox_ubx_interfaces
-  mavros_msgs
+  rtcm_msgs
 )
 
 target_link_libraries(ublox_dgnss_components

--- a/ublox_dgnss_node/package.xml
+++ b/ublox_dgnss_node/package.xml
@@ -16,7 +16,7 @@
   <exec_depend>std_msgs</exec_depend>
   <depend>ublox_ubx_msgs</depend>
   <depend>ublox_ubx_interfaces</depend>
-  <depend>mavros_msgs</depend>
+  <depend>rtcm_msgs</depend>
   <build_depend>pkg-config</build_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/ublox_dgnss_node/src/ublox_dgnss_node.cpp
+++ b/ublox_dgnss_node/src/ublox_dgnss_node.cpp
@@ -56,7 +56,7 @@
 #include "ublox_ubx_interfaces/srv/cold_start.hpp"
 #include "ublox_ubx_interfaces/srv/reset_odo.hpp"
 
-#include "mavros_msgs/msg/rtcm.hpp"
+#include "rtcm_msgs/msg/message.hpp"
 
 using namespace std::chrono_literals;
 using std::placeholders::_1;
@@ -283,7 +283,7 @@ public:
 
     ubx_esf_meas_sub_ = this->create_subscription<ublox_ubx_msgs::msg::UBXEsfMeas>(
       "/ubx_esf_meas_to_device", 10, std::bind(&UbloxDGNSSNode::ubx_esf_meas_callback, this, _1));
-    rtcm_sub_ = this->create_subscription<mavros_msgs::msg::RTCM>(
+    rtcm_sub_ = this->create_subscription<rtcm_msgs::msg::Message>(
       "/ntrip_client/rtcm", 10, std::bind(&UbloxDGNSSNode::rtcm_callback, this, _1));
 
     is_initialising_ = false;
@@ -349,7 +349,7 @@ private:
   rclcpp::Publisher<ublox_ubx_msgs::msg::UBXEsfMeas>::SharedPtr ubx_esf_meas_pub_;
 
   rclcpp::Subscription<ublox_ubx_msgs::msg::UBXEsfMeas>::SharedPtr ubx_esf_meas_sub_;
-  rclcpp::Subscription<mavros_msgs::msg::RTCM>::SharedPtr rtcm_sub_;
+  rclcpp::Subscription<rtcm_msgs::msg::Message>::SharedPtr rtcm_sub_;
 
   rclcpp::Service<ublox_ubx_interfaces::srv::HotStart>::SharedPtr hot_start_service_;
   rclcpp::Service<ublox_ubx_interfaces::srv::WarmStart>::SharedPtr warm_start_service_;
@@ -766,7 +766,7 @@ public:
   }
 
   UBLOX_DGNSS_NODE_LOCAL
-  void rtcm_callback(const mavros_msgs::msg::RTCM & msg) const
+  void rtcm_callback(const rtcm_msgs::msg::Message & msg) const
   {
     if (usbc_ == nullptr || !usbc_->devh_valid()) {
       RCLCPP_WARN(get_logger(), "usbc_ not valid - not sending rtcm to device!");
@@ -778,13 +778,13 @@ public:
     }
     std::ostringstream oss;
     std::vector<u_char> data_out;
-    data_out.resize(msg.data.size());
-    for (auto b : msg.data) {
+    data_out.resize(msg.message.size());
+    for (auto b : msg.message) {
       oss << std::hex << std::setfill('0') << std::setw(2) << +b;
       data_out.push_back(b);
     }
 
-    RCLCPP_DEBUG(get_logger(), "rtcm_callback msg.data: 0x%s", oss.str().c_str());
+    RCLCPP_DEBUG(get_logger(), "rtcm_callback msg.message: 0x%s", oss.str().c_str());
 
     usbc_->write_buffer(data_out.data(), data_out.size());
   }


### PR DESCRIPTION
This is in keeping with a [similar PR](https://github.com/LORD-MicroStrain/ntrip_client/pull/34) for the LORD MicrosStrain NTRIP client where it is commented that
_"[rtcm_msgs](https://github.com/tilk/rtcm_msgs/tree/master) is a smaller dependency with support for both ROS and ROS 2 now, and preferred by some downstream dependencies like [ublox](https://github.com/KumarRobotics/ublox)."_

Format of the messages are structurally identical, with the only difference being the name of the payload ("data" in mavros vs "message" in rtcm_msgs)