### PR TITLE
Add multiple device support, and moving base+rover example

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ Values will be as described in the integration manual (without scaling applied).
   CFG_SFODO_LATENCY
   CFG_SFODO_QUANT_ERROR
 
+### Device Identification Parameters
+
+aka Use with Multiple Devices
+
+By default, the ublox_dgnss node will search for and connect to the first device which matches the ublox USB ID's (vendor ID of 0x1546 and product ID of 0x1546).  If multiple devices are connected simultaneously, the remaining devices will be ignored.  In this situation you have no control over which device is used, since the order in which they are found may depend on the order in which they were physically attached to the host.
+
+If you have multiple ublox devices attached simultaneously and wish to connect to a specific device, you can specify a launch parameter "DEVICE_SERIAL_STRING".  The node will then search for and connect to the first device with this matching serial string.  The device serial string itself should be programmed into the ublox device beforehand using u-center software.  
+
+The frame ID used in ROS2 messages for that device can also be specified using the launch parameter "FRAME_ID".
+
+Note: these parameters are not written to the device.  They only instruct the node on how to behave.
+
 # ROS2 UBX NAV Messages
 
 The following messages may be outputed. They included a `std_msgs/Header header` with the remainder of the fields matching the UBX output. Note that field names use different notation as the UBX field name notation is not compliant with the ROS IDL field names.
@@ -181,6 +193,20 @@ An example launch file is provided. You will need to set values appropriate for 
 ros2 launch ublox_dgnss ntrip_client.launch.py use_https:=true host:=ntrip.data.gnss.ga.gov.au port:=443 mountpoint:=MBCH00AUS0 username:=username password:=password
 ```
 Note the launch file has been configured to also use environment variables `NTRIP_USERNAME` & `NTRIP_PASSWORD` such that you dont need credentials in the launch scripts.
+
+# Moving Base and Rover
+
+The ZED-F9P devices support the "moving base and rover" mode of operation, using two devices on a mobile vehicle to provide both position and orientation data.  Further information on this mode, including physical connections between the two devices and the host machine are included in the following ublox application note.
+
+https://www.u-blox.com/sites/default/files/documents/ZED-F9P-MovingBase_AppNote_UBX-19009093.pdf
+
+Note: the ZED-F9R device does not support this mode.
+
+Example launch configuration files are included as "ublox_mb+r_base.launch.py" and "ublox_mb+r_rover.launch.py" for the base and rover devices respectively.  The base and rover are physically connected similar to that described in Section 2.2.1 "Wired connection between base and rover" in the ublox app note, with UART2 used for the wired connection between base and rover.  Both base and rover connect to the host machine via USB.  Device configuration is similar to that described in Section 2.3.2 "5 Hz navigation rate application" in the app note.
+
+Both base and rover will output position data which can be used to publish NavSatFix messages (as described above).  The rover also outputs heading data via UBX-NAV-RELPOSNED messages.  Refer to Section 2.4 "Using the heading output" in the app note for more information.
+
+Note: as this mode required two ZED-F9P devices connected simultaneously, you will need to configure each device with a different serial string and specify these in the launch files.  See description above on device identification parameters.
 
 # Helpful tips
 

--- a/ublox_dgnss/launch/ublox_mb+r_base.launch.py
+++ b/ublox_dgnss/launch/ublox_mb+r_base.launch.py
@@ -1,0 +1,91 @@
+""" Launch ublox_dgnss_node publishing high precision Lon/Lat messages"""
+import launch
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
+def generate_launch_description():
+  """Generate launch description for ublox_dgnss components."""
+  params_base= [
+            {'DEVICE_SERIAL_STRING': "Test Base"},
+            {'FRAME_ID': "base"},
+
+            # config measurement interval to 200 ms (ie 5 Hz) and nav update rate to once per measurement
+            {'CFG_RATE_MEAS': 0xc8},
+            {'CFG_RATE_NAV': 0x1},
+
+            # disable all messages on UART1
+            {'CFG_UART1INPROT_NMEA': False},
+            {'CFG_UART1INPROT_RTCM3X': False},
+            {'CFG_UART1INPROT_UBX': False},
+            {'CFG_UART1OUTPROT_NMEA': False},
+            {'CFG_UART1OUTPROT_RTCM3X': False},
+            {'CFG_UART1OUTPROT_UBX': False},
+
+            # set UART2 baud rate to 460800
+            {'CFG-UART2-BAUDRATE': 0x70800},
+
+            # send RTCM messages only (to rover) on UART2
+            {'CFG_UART2INPROT_NMEA': False},
+            {'CFG_UART2INPROT_RTCM3X': False},
+            {'CFG_UART2INPROT_UBX': False},
+            {'CFG_UART2OUTPROT_NMEA': False},
+            {'CFG_UART2OUTPROT_RTCM3X': True},
+            {'CFG_UART2OUTPROT_UBX': False},
+
+            # RTCM and UBX messages as required on USB
+            {'CFG_USBINPROT_NMEA': False},
+            {'CFG_USBINPROT_RTCM3X': True},
+            {'CFG_USBINPROT_UBX': True},
+            {'CFG_USBOUTPROT_NMEA': False},
+            {'CFG_USBOUTPROT_RTCM3X': False},
+            {'CFG_USBOUTPROT_UBX': True},
+
+            # output RTCM messages required for moving base+rover mode on UART2
+            {'CFG-MSGOUT-RTCM_3X_TYPE4072_0_UART2': 0x1},
+            {'CFG-MSGOUT-RTCM_3X_TYPE1074_UART2': 0x1},
+            {'CFG-MSGOUT-RTCM_3X_TYPE1084_UART2': 0x1},
+            {'CFG-MSGOUT-RTCM_3X_TYPE1124_UART2': 0x1},
+            {'CFG-MSGOUT-RTCM_3X_TYPE1230_UART2': 0x1},
+
+            # messages required for navsatfix calcs by ROS node
+            {'CFG_MSGOUT_UBX_NAV_HPPOSLLH_USB': 0x1},
+            {'CFG_MSGOUT_UBX_NAV_COV_USB': 0x1},
+            {'CFG_MSGOUT_UBX_NAV_STATUS_USB': 0x1},
+            {'CFG_MSGOUT_UBX_NAV_PVT_USB': 0x1},            
+            ]
+
+  container_base = ComposableNodeContainer(
+    name='ublox_dgnss_moving_base',
+    namespace='',
+    package='rclcpp_components',
+    executable='component_container_mt',
+    composable_node_descriptions=[
+      ComposableNode(
+        package='ublox_dgnss_node',
+        plugin='ublox_dgnss::UbloxDGNSSNode',
+        name='ublox_dgnss',
+        namespace='base',
+        parameters=params_base
+      )
+    ]
+  )
+
+  container_navsatfix = ComposableNodeContainer(
+    name='ublox_nav_sat_fix_hp_container',
+    namespace='',
+    package='rclcpp_components',
+    executable='component_container_mt',
+    composable_node_descriptions=[
+      ComposableNode(
+        package='ublox_nav_sat_fix_hp_node',
+        plugin='ublox_nav_sat_fix_hp::UbloxNavSatHpFixNode',
+        namespace='base',
+        name='ublox_nav_sat_fix_hp'
+      )
+    ]
+  )
+
+  return launch.LaunchDescription([
+    container_base,
+    container_navsatfix,
+    ])

--- a/ublox_dgnss/launch/ublox_mb+r_rover.launch.py
+++ b/ublox_dgnss/launch/ublox_mb+r_rover.launch.py
@@ -1,0 +1,87 @@
+""" Launch ublox_dgnss_node publishing high precision Lon/Lat messages"""
+import launch
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
+def generate_launch_description():
+  """Generate launch description for ublox_dgnss components."""
+  params_rover = [
+            {'DEVICE_SERIAL_STRING': "Test Rover"},
+            {'FRAME_ID': "rover"},
+
+            # config measurement interval to 200 ms (ie 5 Hz) and nav update rate to once per measurement
+            {'CFG_RATE_MEAS': 0xc8},
+            {'CFG_RATE_NAV': 0x1},
+
+            # disable all messages on UART1
+            {'CFG_UART1INPROT_NMEA': False},
+            {'CFG_UART1INPROT_RTCM3X': False},
+            {'CFG_UART1INPROT_UBX': False},
+            {'CFG_UART1OUTPROT_NMEA': False},
+            {'CFG_UART1OUTPROT_RTCM3X': False},
+            {'CFG_UART1OUTPROT_UBX': False},
+
+            # set UART2 baud rate to 460800
+            {'CFG-UART2-BAUDRATE': 0x70800},
+
+            # receive RTCM messages only (from base) on UART2
+            {'CFG_UART2INPROT_NMEA': False},
+            {'CFG_UART2INPROT_RTCM3X': True},
+            {'CFG_UART2INPROT_UBX': False},
+            {'CFG_UART2OUTPROT_NMEA': False},
+            {'CFG_UART2OUTPROT_RTCM3X': False},
+            {'CFG_UART2OUTPROT_UBX': False},
+
+            # send/receive UBX messages only on USB
+            {'CFG_USBINPROT_NMEA': False},
+            {'CFG_USBINPROT_RTCM3X': False},
+            {'CFG_USBINPROT_UBX': True},
+            {'CFG_USBOUTPROT_NMEA': False},
+            {'CFG_USBOUTPROT_RTCM3X': False},
+            {'CFG_USBOUTPROT_UBX': True},
+
+            # messages required for navsatfix calcs by ROS node
+            {'CFG_MSGOUT_UBX_NAV_HPPOSLLH_USB': 0x1},
+            {'CFG_MSGOUT_UBX_NAV_COV_USB': 0x1},
+            {'CFG_MSGOUT_UBX_NAV_STATUS_USB': 0x1},
+            {'CFG_MSGOUT_UBX_NAV_PVT_USB': 0x1},
+
+            # output relative position messages
+            {'CFG_MSGOUT_UBX_NAV_RELPOSNED_USB': 0x1},
+            ]
+
+  container_rover = ComposableNodeContainer(
+    name='ublox_dgnss_rover',
+    namespace='',
+    package='rclcpp_components',
+    executable='component_container_mt',
+    composable_node_descriptions=[
+      ComposableNode(
+        package='ublox_dgnss_node',
+        plugin='ublox_dgnss::UbloxDGNSSNode',
+        name='ublox_dgnss',
+        namespace='rover',
+        parameters=params_rover
+      )
+    ]
+  )
+
+  container_navsatfix = ComposableNodeContainer(
+    name='ublox_nav_sat_fix_hp_container',
+    namespace='',
+    package='rclcpp_components',
+    executable='component_container_mt',
+    composable_node_descriptions=[
+      ComposableNode(
+        package='ublox_nav_sat_fix_hp_node',
+        plugin='ublox_nav_sat_fix_hp::UbloxNavSatHpFixNode',
+        namespace='rover',
+        name='ublox_nav_sat_fix_hp'
+      )
+    ]
+  )
+
+  return launch.LaunchDescription([
+    container_rover,
+    container_navsatfix,
+    ])

--- a/ublox_dgnss_node/include/ublox_dgnss_node/usb.hpp
+++ b/ublox_dgnss_node/include/ublox_dgnss_node/usb.hpp
@@ -92,6 +92,7 @@ private:
   int log_level_;
   int vendor_id_;
   int product_id_;
+  std::string serial_str_;
   int class_id_;
   int ep_data_out_addr_;
   int ep_data_in_addr_;
@@ -112,6 +113,7 @@ private:
   std::deque<std::shared_ptr<transfer_t>> transfer_queue_;
 
 private:
+  libusb_device_handle* open_device_with_serial_string(libusb_context* ctx, int vendor_id, int product_id, std::string serial_str);
 // this is called after the out transfer to USB from HOST has been received by libusb
   void callback_out(struct libusb_transfer * transfer);
 // this is called when the stat for in is available - from USB in HOST
@@ -136,9 +138,9 @@ private:
 
 public:
   void init();  // throws exception on failure
-  void open_device();  // throws exception on failure
+  bool open_device();  // returns false on failure
   void init_async();  // throws exception on failure
-  Connection(int vendor_id, int product_id, int log_level = LIBUSB_OPTION_LOG_LEVEL);
+  Connection(int vendor_id, int product_id, std::string serial_str, int log_level = LIBUSB_OPTION_LOG_LEVEL);
   ~Connection();
   void set_in_callback(connection_in_cb_fn in_cb_fn)
   {
@@ -167,6 +169,10 @@ public:
   int product_id()
   {
     return product_id_;
+  }
+  std::string serial_str()
+  {
+    return serial_str_;
   }
   bool inline devh_valid()
   {


### PR DESCRIPTION
Add ability to connect to a specific device when multiple ublox devices are connected simultaneously, by matching to specified device serial string.  Addresses issue https://github.com/aussierobots/ublox_dgnss/issues/5

Also added example of configuring two ZED-F9P devices in moving base+rover mode.