### PR TITLE
chore: set user-agent for caster http requests

### DIFF
--- a/ntrip_client_node/src/ntrip_client_node.cpp
+++ b/ntrip_client_node/src/ntrip_client_node.cpp
@@ -83,6 +83,7 @@ public:
       curl_easy_setopt(handle, CURLOPT_USERPWD, userpwd.c_str());
       // curl_easy_setopt(handle, CURLOPT_NOPROGRESS, 0L);
       // curl_easy_setopt(handle, CURLOPT_VERBOSE, 1L);
+      curl_easy_setopt(handle, CURLOPT_USERAGENT, "NTRIP ros2/ublox_dgnss");
       curl_easy_setopt(handle, CURLOPT_FAILONERROR, true);
       curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, &NTRIPClientNode::WriteCallback);
       curl_easy_setopt(curlHandle_->handle, CURLOPT_WRITEDATA, this);


### PR DESCRIPTION
Some public caster servers (like caster.centipede.fr) requires specific user agents for streaming requests (NTRIP as first string in the agent).