### PR TITLE
added printing serial_str_ & serial_num_string to error of not finding device with specificed serial string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ aka Use with Multiple Devices
 
 By default, the ublox_dgnss node will search for and connect to the first device which matches the ublox USB ID's (vendor ID of 0x1546 and product ID of 0x01a9).  If multiple devices are connected simultaneously, the remaining devices will be ignored.  In this situation you have no control over which device is used, since the order in which they are found may depend on the order in which they were physically attached to the host.
 
-If you have multiple ublox devices attached simultaneously and wish to connect to a specific device, you can specify a launch parameter "DEVICE_SERIAL_STRING".  The node will then search for and connect to the first device with this matching serial string.  The device serial string itself should be programmed into the ublox device beforehand using u-center software.
+If you have multiple ublox devices attached simultaneously and wish to connect to a specific device, you can specify a launch parameter "DEVICE_SERIAL_STRING".  The node will then search for and connect to the first device with this matching serial string.  The device serial string "CFG-USB-SERIAL_NO_STRx" itself should be programmed into the ublox device beforehand using u-center software.
 
 The frame ID used in ROS2 messages for that device can also be specified using the launch parameter "FRAME_ID".
 

--- a/ublox_dgnss_node/include/ublox_dgnss_node/usb.hpp
+++ b/ublox_dgnss_node/include/ublox_dgnss_node/usb.hpp
@@ -115,7 +115,7 @@ private:
 private:
   libusb_device_handle * open_device_with_serial_string(
     libusb_context * ctx, int vendor_id,
-    int product_id, std::string serial_str);
+    int product_id, std::string serial_str, char * serial_num_string);
 // this is called after the out transfer to USB from HOST has been received by libusb
   void callback_out(struct libusb_transfer * transfer);
 // this is called when the stat for in is available - from USB in HOST

--- a/ublox_dgnss_node/src/usb.cpp
+++ b/ublox_dgnss_node/src/usb.cpp
@@ -93,7 +93,8 @@ void Connection::init()
 libusb_device_handle * Connection::open_device_with_serial_string(
   libusb_context * ctx,
   int vendor_id, int product_id,
-  std::string serial_str)
+  std::string serial_str,
+  char *serial_num_string)
 {
   libusb_device_handle * devHandle = nullptr;
   int rc = 0;
@@ -129,7 +130,7 @@ libusb_device_handle * Connection::open_device_with_serial_string(
       throw std::string("Error opening device: ") + libusb_error_name(rc);
     }
 
-    char serial_num_string[256];
+    
     // Read the serial number string
     rc = libusb_get_string_descriptor_ascii(
       devHandle, desc.iSerialNumber,
@@ -162,13 +163,15 @@ libusb_device_handle * Connection::open_device_with_serial_string(
 
 bool Connection::open_device()
 {
-  devh_ = open_device_with_serial_string(ctx_, vendor_id_, product_id_, serial_str_);
+  char serial_num_string[256];
+  devh_ = open_device_with_serial_string(ctx_, vendor_id_, product_id_, serial_str_, serial_num_string);
   if (!devh_) {
     if (serial_str_.empty()) {
       throw std::string("Error finding USB device");
       // std::cerr << "Error finding ublox USB device (no serial string supplied)";
     } else {
-      throw std::string("Error finding USB device with specified serial string");
+      throw std::string("Error finding USB device with specified serial string, looking for \"") + 
+        serial_str_ + "\" however \"" + serial_num_string + "\" was found.";
       // std::cerr << "Error finding ublox USB device with specified serial string";
     }
     return false;


### PR DESCRIPTION
Where feature was added?
If DEVICE_SERIAL_STRING is set, and there are no devices with this serial string found, but there is a device found with different serial string, then error of "Error finding USB device with specified serial string" is triggered  

What feature was added?
The error message returns requested DEVICE_SERIAL_STRING and the serial string from device that was not matching. 

Why? 
Makes it much easier to debug device's serial string as u-center might not correctly convert hex to string, inputting "base" can result in "esab".

Sample output before feature:
`[component_container_mt-1] [ERROR] [1711973415.228204225] [base.ublox_dgnss]: usb init error: Error finding USB device with specified serial string`
Sample output after feature:
`[component_container_mt-1] [ERROR] [1711973415.228204225] [base.ublox_dgnss]: usb init error: Error finding USB device with specified serial string, looking for "Test Base" however "esab" was found.`

-Tested via connecting more than once device which one of them has the correct serial string, the error is not being triggered and connection is successful to one that is matching, the usb.cpp is already handling this. 

Thanks :) 