### PR TITLE
Fixing UBX-NAV-SVIN reading

### DIFF
--- a/ublox_dgnss_node/include/ublox_dgnss_node/ubx/ubx_nav.hpp
+++ b/ublox_dgnss_node/include/ublox_dgnss_node/ubx/ubx_nav.hpp
@@ -247,6 +247,9 @@ public:
       case ubx::UBX_NAV_STATUS:
         status_->frame(frame);
         break;
+      case ubx::UBX_NAV_SVIN:
+        svin_->frame(frame);
+        break;
       case ubx::UBX_NAV_RELPOSNED:
         relposned_->frame(frame);
         break;


### PR DESCRIPTION
This PR adds a minor fix to enable proper receival of `UBX-NAV-SVIN` messages.

Previously, `UBX-NAV-SVIN` messages could be received from the GPS device, but they could not be parsed and published onto the `ubx_nav_svin` topic. Instead, the failed parsing caused error messages to be logged from the code. (I seem to have missed this in an earlier PR.)

I've tested these changes locally and I can now receive messages published onto the `ubx_nav_svin` topic.

Running `colcon test` on these changes also passes.