### PR TITLE
Address USB memory corruption crashes and RAWX frame length

### DIFF
--- a/ublox_dgnss_node/include/ublox_dgnss_node/usb.hpp
+++ b/ublox_dgnss_node/include/ublox_dgnss_node/usb.hpp
@@ -27,6 +27,7 @@
 #include <deque>
 #include <vector>
 #include <memory>
+#include <mutex>
 
 #define F9_VENDOR_ID      0x1546   // U-Blox AG
 #define F9_PRODUCT_ID     0x01a9   // u-blox GNSS receiver
@@ -111,6 +112,7 @@ private:
   size_t err_count_ = 0;
 
   std::deque<std::shared_ptr<transfer_t>> transfer_queue_;
+  mutable std::mutex transfer_queue_mutex_;  // Protects transfer_queue_ access
 
 private:
   libusb_device_handle * open_device_with_serial_string(


### PR DESCRIPTION
Was having difficulty running the ublox_dgnss node for extended periods without memory related crashes, and also noticed that all RAWX packets were failing checksums.

Implemented changes to address USB memory issues causing crashes after running for extended periods:
- Fix use-after-free bug in callback_in() and callback_out() by saving user_data before freeing transfer
- Add mutex protection for thread-safe access to transfer_queue_
- Fix iterator invalidation in cleanup_transfer_queue()
- Improved transfer cancellation during shutdown
- Prevent crashes from corrupted double-linked list, invalid free, and libusb assertions

Also addressed underlying frame length issue which resulted in RAWX checksum failures (USB callback was copying the entire USB buffer as a single UBX frame, including extra data appended after the actual frame).  Fix includes:
- Parse the UBX frame length from header bytes 4-5
- Copy only the exact frame bytes instead of the entire USB buffer
- Handle multiple messages in a single USB transfer

ublox_dgnss now running for extended periods without crashes, and RAWX checksums passing.

Apologies for merging two seperate issues here.