### PR TITLE
Replaced libcurl_vendor package with deb or pixi

### DIFF
--- a/ntrip_client_node/CMakeLists.txt
+++ b/ntrip_client_node/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(rtcm_msgs REQUIRED)
-find_package(libcurl_vendor REQUIRED)
+find_package(CURL REQUIRED)
 
 include_directories(include SYSTEM)
 

--- a/ntrip_client_node/package.xml
+++ b/ntrip_client_node/package.xml
@@ -13,7 +13,7 @@
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>libcurl_vendor</depend>
+  <depend>libcurl-dev</depend>
   <exec_depend>std_msgs</exec_depend>
   <depend>rtcm_msgs</depend>
   <build_depend>pkg-config</build_depend>


### PR DESCRIPTION
We removed `libcurl_vendor` package https://github.com/ros/resource_retriever/pull/116/files to use the system library