### PR TITLE
Fix USB hotplug attach skip on startup by initializing `attached_`

### DIFF
--- a/ublox_dgnss_node/src/usb.cpp
+++ b/ublox_dgnss_node/src/usb.cpp
@@ -44,6 +44,7 @@ Connection::Connection(
   timeout_ms_ = 250;
   timeout_tv_ = {1, 0};       // default the timeout to 1 seconds
   keep_running_ = true;
+  attached_ = false;
 
   driver_state_ = USBDriverState::DISCONNECTED;
 


### PR DESCRIPTION
# Summary

- Fix #61 

Initialize `usb::Connection::attached_` to false in the constructor.
Prevents the hotplug attach callback from being skipped when the device is already connected at startup.

# Problem
When the device is already connected at startup, `attached_` may start with a non‑zero garbage value.
`hotplug_attach_callback()` then skips `open_device()` because it checks `if (!attached_)`, leading to repeated
```bash
USB not connection cant handle parameter processing!!
```
logs until the device is replugged.

# Fix
Set 
```c++
attached_ = false
```
in the constructor to guarantee deterministic startup behavior.

