### PR TITLE
Refactor ubx_config_loader to simplify package share path

### DIFF
--- a/ublox_dgnss_node/src/ubx_config_loader.cpp
+++ b/ublox_dgnss_node/src/ubx_config_loader.cpp
@@ -22,11 +22,13 @@
 #include <vector>
 #include <fstream>
 
-#ifdef ROS_DISTRO_humble
+// get_package_share_path.hpp does not exist in any ROS2 release of
+// ament_index_cpp (Humble through Rolling) — the std::filesystem::path
+// variant is an overload inside get_package_share_directory.hpp itself,
+// not a separate header. The distro branch below was unnecessary: the
+// string-returning get_package_share_directory() works identically on
+// every distro, so just use it unconditionally.
 #include <ament_index_cpp/get_package_share_directory.hpp>
-#else
-#include <ament_index_cpp/get_package_share_path.hpp>
-#endif
 
 namespace
 {
@@ -237,11 +239,7 @@ ubx_cfg_item_map_t UbxConfigLoader::load_from_toml(
 
 std::string UbxConfigLoader::get_default_toml_path(const std::string & device_family)
 {
-  #ifdef ROS_DISTRO_humble
   auto package_share = ament_index_cpp::get_package_share_directory("ublox_dgnss");
-  #else
-  auto package_share = ament_index_cpp::get_package_share_path("ublox_dgnss").string();
-  #endif
 
   std::string family_lower = device_family;
   std::transform(


### PR DESCRIPTION
TLDR: Removed conditional compilation for ROS_DISTRO_humble and unified the inclusion of get_package_share_directory.

## Fix build on Jazzy/Rolling: `get_package_share_path.hpp` doesn't exist

Ran into a build failure on ROS 2 Jazzy:

```
fatal error: ament_index_cpp/get_package_share_path.hpp: No such file or directory
```

Turns out `ubx_config_loader.cpp` branches like this:

```cpp
#ifdef ROS_DISTRO_humble
#include <ament_index_cpp/get_package_share_directory.hpp>
#else
#include <ament_index_cpp/get_package_share_path.hpp>
#endif
```

but `get_package_share_path.hpp` isn't a real file — it's never existed in `ament_index_cpp`, on Humble, Jazzy, Rolling, any of it. The `std::filesystem::path` version is just an overload that lives inside `get_package_share_directory.hpp`:

```cpp
void get_package_share_directory(const std::string& package_name, std::filesystem::path& path);
```

So the fix is to just to drop the distro branch — `get_package_share_directory("ublox_dgnss")` (the plain string-returning version) already works the same everywhere, no need to special-case Humble at all.

Guessing this slipped through because `UbxConfigLoader`/the TOML config filtering is pretty new, and it's probably only been built on Humble so far — the `#else` branch never actually got compiled until now.

Tested on Jazzy, builds clean. Behavior's identical either way.